### PR TITLE
ignore unnamed FIELDSET elements

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,10 +6,11 @@ var NODE_LIST_CLASSES = {
 , '[object RadioNodeList]': true
 }
 
-var BUTTON_INPUT_TYPES = {
+var IGNORED_INPUT_TYPES = {
   'button': true
 , 'reset': true
 , 'submit': true
+, 'fieldset': true
 }
 
 var CHECKED_INPUT_TYPES = {
@@ -45,7 +46,7 @@ function getFormData(form, options) {
   // Get unique submittable element names for the form
   for (var i = 0, l = form.elements.length; i < l; i++) {
     var element = form.elements[i]
-    if (BUTTON_INPUT_TYPES[element.type] || element.disabled) {
+    if (IGNORED_INPUT_TYPES[element.type] || element.disabled) {
       continue
     }
     elementName = element.name || element.id


### PR DESCRIPTION
Surprisingly, `fieldset` gets added to form.elements, despite not having a `value` attribute.

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/fieldset

Renamed BUTTON_INPUT_TYPES to IGNORED_INPUT_TYPES and added fieldset to the list.
